### PR TITLE
Fix harvesters to completely unload energy

### DIFF
--- a/role.harvester.js
+++ b/role.harvester.js
@@ -2,7 +2,13 @@ var roleHarvester = {
 
     /** @param {Creep} creep **/
     run: function(creep) {
-        if(creep.carry.energy < creep.carryCapacity) {
+        if(!creep.memory.harvesting && creep.carry.energy == 0) {
+            creep.memory.harvesting = true;
+        }
+        if(creep.memory.harvesting && creep.carry.energy == creep.carryCapacity) {
+            creep.memory.harvesting = false;
+        }
+        if(creep.memory.harvesting) {
             var sources = creep.room.find(FIND_SOURCES);
             if(creep.harvest(sources[0]) == ERR_NOT_IN_RANGE) {
                 creep.moveTo(sources[0]);


### PR DESCRIPTION
Harvesters unload once then go back to refill. Causes lack of energy to make creeps.

Fixed in this PR