### PR TITLE
Add creeps going to dead energy source

### DIFF
--- a/role.builder.js
+++ b/role.builder.js
@@ -82,7 +82,6 @@ RoleBuilder.prototype.run = function run() {
     } else {
         this.work();
     }
-    console.log("status", this.memory.getting_energy, this.creep.carry.energy);
     // check if should switch task
     if (!this.memory.getting_energy && this.creep.carry.energy == 0) {
         // shoud start gathering energy
@@ -107,7 +106,6 @@ RoleBuilder.prototype.getEnergy = function getEnergy() {
 
 RoleBuilder.prototype.work = function work() {
     const target = Game.getObjectById(this.creep.memory.target);
-    console.log(target);
     if (target) {
         const res = this.creep.build(target);
         if (res == ERR_NOT_IN_RANGE) {

--- a/util.get_energy.js
+++ b/util.get_energy.js
@@ -6,5 +6,7 @@ module.exports = (creep, log = false) => {
     }
     if(res == ERR_NOT_IN_RANGE) {
         creep.moveTo(source);
+    } else if(res == ERR_NOT_ENOUGH_ENERGY) {
+        creep.moveTo(source);
     }
 }


### PR DESCRIPTION
This should fix the lifelessness in a colony when the source is dead...
Creeps will go to the source to avoid the time taken to move after the source is refilled